### PR TITLE
do not run on NixOS

### DIFF
--- a/install.nix
+++ b/install.nix
@@ -53,6 +53,12 @@ let
   };
 in
   pkgs.writeShellScriptBin "install.sh" ''
+
+    if grep 'NAME=NixOS' /etc/os-release > /dev/null; then
+      echo "This script is not supported on NixOS, your environment is already configured by administrator."
+      exit 1
+    fi
+
     if ! which newuidmap > /dev/null; then
       echo "newuidmap command not found"
       echo "please install the uidmap package via 'sudo apt install -y uidmap' and run this script again"


### PR DESCRIPTION
```
[lblasc@obsidian:~/rootless-podman]$ $(nix-build https://github.com/tvbeat/rootless-podman/archive/no-nixos.tar.gz -A outputs.packages.x86_64-linux.install)/bin/install.sh
...
building '/nix/store/jlhd7kgyfv0a66k0y9z2hk009i9zc825-docker-podman-compat.drv'...
building '/nix/store/108c5bn723ffpaigsdmqrazj06yn0m89-podman.service.drv'...
building '/nix/store/ffbhic4b66rrk5fl6lipm1cfawqjlzvw-tvbeat.podman-env.drv'...
created 17 symlinks in user environment
building '/nix/store/39i1swy0s6zghsswcmby1dp6rn3dpszy-install.sh.drv'...
This script is not supported on NixOS, your environment is already configured by administrator.
```